### PR TITLE
Refactor Todo types for export and new type creation

### DIFF
--- a/JS-TS/solutions/types.ts
+++ b/JS-TS/solutions/types.ts
@@ -1,9 +1,15 @@
-interface Todo {
-
+export interface Todo {
+ id: number;
+ title:  string;
+ description?:  string;
+ status: TodoStatus;
+readonly createdAt: Date;
 }
 
-enum TodoStatus {
-
+export enum TodoStatus {
+  PENDING = "PENDING",
+  IN_PROGRESS = "IN_PROGRESS",
+  COMPLETED = "COMPLETED",
 }
 
-export { Todo, TodoStatus };
+export type NewTodo = Omit<Todo, "id" | "createdAt">;


### PR DESCRIPTION
Export Todo interface and TodoStatus enum. Introduce NewTodo type omitting id and createdAt.